### PR TITLE
Fix NameError: Add missing defaultdict import

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -12,6 +12,7 @@ from pycocotools.cocoeval import COCOeval
 from typing import Dict, Any, Optional
 import json
 import time
+from collections import defaultdict
 
 from swin_maskrcnn.models.mask_rcnn import SwinMaskRCNN
 from swin_maskrcnn.data.dataset import CocoDataset


### PR DESCRIPTION
## Summary
- Fixed NameError by adding missing defaultdict import to scripts/train.py

## Test plan
- Verify that the training script runs without NameError when calculating validation loss
- Run the training script to ensure validation loss calculation works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)